### PR TITLE
Added TLS scopes note to Auth page

### DIFF
--- a/src/pages/getting_started/index.md
+++ b/src/pages/getting_started/index.md
@@ -31,6 +31,12 @@ The required parameters are:
 - `client_secret`: The Client secret.
 - `scope`: The scopes are `openid`, `AdobeID`, `firefly_api`, `ff_apis`.
 
+<InlineAlert variant="warning" slots="header, text" />
+
+Tokens for TLS need additional scopes
+
+Translate and Lip Sync (TLS) tokens can be generated but MAY NOT BE VALID without two cards included on your developer console project. To authenticate the TLS API, add another API from the Firefly services family to your project on the Adobe developer console.
+
 Automate your token generation by calling the IMS endpoint above using standard OAuth2 libraries. Using industry-standard libraries is the quickest and most secure way of integrating with OAuth.
 
 Be diligent when choosing the OAuth 2.0 library that works best for your application. Your teams' projects likely leverage OAuth libraries already to connect with other APIs. It's recommended to use these libraries to automatically generate tokens when they expire.


### PR DESCRIPTION
Added TLS scopes information to avoid "user_not_entitled" errors.

## Description

TSL API requires particular scopes in Dev Console. See [the channel thread addressing this error](https://creativecloud.slack.com/archives/C06QR6VLDFZ/p1747407036312389).


## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
