### PR TITLE
Patch/correct locale code

### DIFF
--- a/src/pages/api/index.md
+++ b/src/pages/api/index.md
@@ -3,6 +3,7 @@ title: Avatar and TTS API reference
 description: The API reference page for Avatar and TTS API services.
 contributors:
   - https://github.com/BaskarMitrah
+  - https://github.com/AEAbreu-hub
 ---
 
-<RedoclyAPIBlock src="/audio-video-firefly-services/openapi/audio-video-api.json" scrollYOffset={64} generateCodeSamples="languages: [{lang: 'curl'}]" />
+<RedoclyAPIBlock src="/audio-video-firefly-services/openapi/audio-video-api.json" hideTryItPanel scrollYOffset={64} generateCodeSamples="languages: [{lang: 'curl'}]" />

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -45,7 +45,7 @@
         "operationId": "voices",
         "responses": {
           "200": {
-            "description": "Successful response",
+            "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -2308,13 +2308,10 @@
           "source": {
             "$ref": "#/components/schemas/Source",
             "description": "The pre-signed URL to download the translated/edited transcripts."
-          },
-          "localeCode": {
-            "$ref": "#/components/schemas/TargetLocaleCodes"
           }
         },
         "required": ["source"],
-        "description": "Transcript input details for transcribe request."
+        "description": "Transcript input details for a transcribe request."
       },
       "TargetLocaleCodes": {
         "type": "string",

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -2021,16 +2021,21 @@
             "format": "uri",
             "description": "The pre-signed URL pointing to the input source."
           }
-        }
+        },
+        "required": ["url"],
+        "description": "Source details including a pre-signed URL for accessing the input media."
       },
       "Destination": {
         "type": "object",
         "properties": {
           "url": {
             "type": "string",
-            "description": "The pre-signed URL pointing to the output source."
+            "format": "uri",
+            "description": "The pre-signed URL pointing to the output destination."
           }
-        }
+        },
+        "required": ["url"],
+        "description": "Destination details including a pre-signed URL for the output media."
       },
       "DubRequest": {
         "type": "object",

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -1969,7 +1969,7 @@
         "properties": {
           "targetLocaleCodes": {
             "type": "array",
-            "description": "See the usage notes for more about [these supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support).",
+            "description": "This determines the language used in the processed media output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support).",
             "items": {
               "$ref": "#/components/schemas/TargetLocaleCodes"
             }
@@ -2057,7 +2057,7 @@
             "items": {
               "$ref": "#/components/schemas/TargetLocaleCodes"
             },
-            "description": "See the usage notes for more about [these supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
+            "description": "This determines the language used in the processed media output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
           },
           "transcripts": {
             "type": "array",
@@ -2080,7 +2080,7 @@
             "items": {
               "$ref": "#/components/schemas/TargetLocaleCodes"
             },
-            "description": "See the usage notes for more about [these supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
+            "description": "This determines the language used in the processed media output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
           },
           "transcripts": {
             "type": "array",

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -3241,11 +3241,7 @@
             },
             "mediaType": "audio/wav"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "en-US"
-            }
-          ]
+          "targetLocaleCodes": ["en-US"]
         }
       },
       "AudioInputToGenerateTranscriptFromTargetLanguageAudio": {
@@ -3257,11 +3253,7 @@
             },
             "mediaType": "audio/wav"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "es-ES"
-            }
-          ]
+          "targetLocaleCodes": ["es-ES"]
         }
       },
       "VideoInputToGenerateTranscriptFromSourceVideo": {
@@ -3273,11 +3265,7 @@
             },
             "mediaType": "video/mp4"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "en-US"
-            }
-          ]
+          "targetLocaleCodes": ["en-US"]
         }
       },
       "VideoInputToGenerateTranscriptFromTargetLanguageVideo": {
@@ -3289,11 +3277,7 @@
             },
             "mediaType": "video/mp4"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "es-ES"
-            }
-          ]
+          "targetLocaleCodes": ["es-ES"]
         }
       },
       "AudioInputToGenerateTranscriptAndCaptionsFromTargetFormatsFromSourceAudio": {
@@ -3305,11 +3289,7 @@
             },
             "mediaType": "audio/wav"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "en-US"
-            }
-          ],
+          "targetLocaleCodes": ["en-US"],
           "captions": {
             "targetFormats": ["SRT"]
           }
@@ -3324,11 +3304,7 @@
             },
             "mediaType": "video/mp4"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "en-US"
-            }
-          ],
+          "targetLocaleCodes": ["en-US"],
           "captions": {
             "targetFormats": ["SRT"]
           }
@@ -3476,11 +3452,7 @@
             },
             "mediaType": "video/mp4"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "es-ES"
-            }
-          ],
+          "targetLocaleCodes": ["es-ES"],
           "lipSync": true
         }
       },
@@ -3493,11 +3465,7 @@
             },
             "mediaType": "audio/wav"
           },
-          "targetLocaleCodes": [
-            {
-              "localeCode": "es-ES"
-            }
-          ]
+          "targetLocaleCodes": ["es-ES"]
         }
       },
       "DubRequestUsingEditedSourceTranscript": {
@@ -3517,11 +3485,7 @@
               "localeCode": "en-US"
             }
           ],
-          "targetLocaleCodes": [
-            {
-              "localeCode": "es-ES"
-            }
-          ],
+          "targetLocaleCodes": ["es-ES"],
           "lipSync": true
         }
       },
@@ -3542,11 +3506,7 @@
               "localeCode": "en-US"
             }
           ],
-          "targetLocaleCodes": [
-            {
-              "localeCode": "es-ES"
-            }
-          ]
+          "targetLocaleCodes": ["es-ES"]
         }
       },
       "DubRequestUsingEditedTranslatedTranscript": {

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -1,6 +1,5 @@
 {
   "openapi": "3.1.0",
-  "x-hideTryItPanel": true,
   "info": {
     "version": "1.0.0",
     "title": "Firefly Services Audio/Video API",

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -1,5 +1,6 @@
 {
   "openapi": "3.1.0",
+  "x-hideTryItPanel": true,
   "info": {
     "version": "1.0.0",
     "title": "Firefly Services Audio/Video API",

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -3483,8 +3483,7 @@
             {
               "source": {
                 "url": "<pre-signed url for downloading the edited transcript>"
-              },
-              "localeCode": "en-US"
+              }
             }
           ],
           "targetLocaleCodes": ["es-ES"],
@@ -3504,8 +3503,7 @@
             {
               "source": {
                 "url": "<pre-signed url for downloading the edited transcript>"
-              },
-              "localeCode": "en-US"
+              }
             }
           ],
           "targetLocaleCodes": ["es-ES"]
@@ -3524,8 +3522,7 @@
             {
               "source": {
                 "url": "<pre-signed url for downloading the edited translated transcript>"
-              },
-              "localeCode": "es-ES"
+              }
             }
           ],
           "lipSync": true
@@ -3544,8 +3541,7 @@
             {
               "source": {
                 "url": "<pre-signed url for downloading the edited translated transcript>"
-              },
-              "localeCode": "es-ES"
+              }
             }
           ]
         }

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -1226,7 +1226,7 @@
             }
           },
           "429": {
-            "description": "Too many requests",
+            "description": "Too Many Requests",
             "content": {
               "application/json": {
                 "schema": {

--- a/static/openapi/audio-video-api.json
+++ b/static/openapi/audio-video-api.json
@@ -1969,7 +1969,7 @@
         "properties": {
           "targetLocaleCodes": {
             "type": "array",
-            "description": "This determines the language used in the processed media output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support).",
+            "description": "This determines the language used in the processed output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support).",
             "items": {
               "$ref": "#/components/schemas/TargetLocaleCodes"
             }
@@ -2057,7 +2057,7 @@
             "items": {
               "$ref": "#/components/schemas/TargetLocaleCodes"
             },
-            "description": "This determines the language used in the processed media output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
+            "description": "This determines the language used in the processed output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
           },
           "transcripts": {
             "type": "array",
@@ -2080,7 +2080,7 @@
             "items": {
               "$ref": "#/components/schemas/TargetLocaleCodes"
             },
-            "description": "This determines the language used in the processed media output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
+            "description": "This determines the language used in the processed output. See the usage notes for more about [the supported languages](https://developer.adobe.com/audio-video-firefly-services/getting_started/usage/#language-support)."
           },
           "transcripts": {
             "type": "array",


### PR DESCRIPTION
Remove localeCode attribute from TLS endpoints where they are no longer defined by the user. Schema and examples.

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

https://adobeprovideo.slack.com/archives/C08BFKHK7TR/p1747280298526789?thread_ts=1747159961.257399&cid=C08BFKHK7TR

[Alexander Abreu  8:02 AM]
Tyty. You can see the change by comparing to the live doc. I removed the nested localeCode from the TargetLocaleCodes object

[Sandeep Yadav. 8:32 AM]
Ok, I see the change you mention - https://github.com/AdobeDocs/ffs-audio-video-API/commit/b3a118c793e36431826bd86a79a53d79306bdcac. This is perfect.
I can still see some gap in these two lines:
- https://github.com/AdobeDocs/ffs-audio-video-API/blob/patch/correctLocaleCode/static/openapi/audio-video-api.json#L3490
- https://github.com/AdobeDocs/ffs-audio-video-API/blob/patch/correctLocaleCode/static/openapi/audio-video-api.json#L3511
We do not want "localeCode" inside "transcripts" objects here.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
